### PR TITLE
feat: Add Consent Mode badge display in status column

### DIFF
--- a/front/crawler-monitor/src/components/ResultsTable.css
+++ b/front/crawler-monitor/src/components/ResultsTable.css
@@ -224,6 +224,12 @@
   border: 1px solid var(--error-border, #FCA5A5);
 }
 
+.results-table .status-badge.status-consent-mode {
+  background-color: #EDE9FE;
+  color: #6B21A8;
+  border: 1px solid #9333EA;
+}
+
 .results-table .status-badge.status-check-needed {
   background-color: #DBEAFE;
   color: #1E40AF;

--- a/front/crawler-monitor/src/components/ResultsTable.js
+++ b/front/crawler-monitor/src/components/ResultsTable.js
@@ -258,7 +258,8 @@ function ResultsTable({ results, allResults, runId, loading, error, onRetry }) {
                     const displayStatus = getPropertyDisplayStatus(
                       result.properties?.current_status || result.property_status,
                       calculateHasIssues(result),
-                      result.issues?.length || 0
+                      result.issues?.length || 0,
+                      result
                     );
                     return (
                       <div className="status-display">


### PR DESCRIPTION
## Summary

This PR implements a new Consent Mode badge display in the results table status column to replace the generic "오류발생" error message when Google Consent Mode is detected.

## Changes

### Modified Files
- `front/crawler-monitor/src/utils/propertyStatusUtils.js`
  - Added `hasConsentModeIssue()` helper function to detect `consent_mode_basic_detected` issue type
  - Modified `getPropertyDisplayStatus()` to accept full result object (4th parameter)
  - Added Scenario G for Consent Mode with Priority 2
  - Updated all internal function calls to pass result object
  - Updated priority numbers for all scenarios

- `front/crawler-monitor/src/components/ResultsTable.js`
  - Updated status display logic to pass result object to `getPropertyDisplayStatus()`

- `front/crawler-monitor/src/components/ResultsTable.css`
  - Added `.status-consent-mode` styling with purple color scheme

## Features

- 🔒 Dedicated Consent Mode badge with lock icon
- Priority 2 for high visibility (after urgent errors, before normal errors)
- Purple color scheme (#EDE9FE background, #6B21A8 text, #9333EA border)
- Automatic detection based on backend's `consent_mode_basic_detected` issue type

## Test Plan

1. Verify that properties with `consent_mode_basic_detected` issue display "Consent Mode" badge
2. Confirm purple color scheme is applied correctly
3. Check that priority ordering works (Consent Mode shown before regular errors)
4. Test with property `ae68b6d1-1a08-417c-83a5-4ec9f22ea56b` ([br]aestura)

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)